### PR TITLE
Add lint gh-action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,27 @@
+---
+name: lint
+'on':
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  yamllint:
+    name: Yamllint
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install yamllint
+
+      - name: Lint all the YAMLs.
+        run: yamllint .


### PR DESCRIPTION
Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>


**Description of the change**

- Add lint gh-action that uses yamllint to lint all yaml files on pull requests and pushes to the main branch

**Benefits**

- Ensures that all pull requests contain linted yaml files.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A