### PR TITLE
Add markdown-link-check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,3 +44,11 @@ jobs:
 
       - name: Lint all the markdown files.
         run: markdownlint .
+
+  markdown-link-check:
+    name: Markdown link check
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,9 @@ repos:
       - id: markdownlint
         name: Run markdownlint
         description: Lint markdown files
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.12
+    hooks:
+      - id: markdown-link-check
+        name: Run markdown-link-check
+        description: Check link in markdown files

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,6 +28,13 @@ tasks:
     cmds:
       - task: yamllint
       - task: markdownlint
+      - task: linkcheck
+
+  linkcheck:
+    desc: Run markdown-link-check
+    cmds:
+      - ./hack/linkcheck.sh
+    ignore_error: true
 
   markdownlint:
     desc: Run markdownlint-cli

--- a/docs/our-helm-charts/common-library-add-ons.md
+++ b/docs/our-helm-charts/common-library-add-ons.md
@@ -59,7 +59,7 @@ through a VPN.
 This example shows how to add a Wireguard sidecar to our
 [qBittorrent Helm chart](https://github.com/k8s-at-home/charts/tree/master/charts/qbittorrent).
 It does not cover all of the configuration possibilities of the
-[Wireguard client image](https://github.com/k8s-at-home/container-images/tree/main/wireguard),
+[Wireguard client image](https://github.com/k8s-at-home/container-images/tree/main/apps/wireguard),
 but should give a good starting point for configuring a similar setup.
 
 ### Example values
@@ -69,7 +69,7 @@ container with **all** its traffic routed through a VPN. In order to have
 functioning ingress and/or probes, it might be required to open certain
 networks or ports on the VPN firewall. That is beyond the scope of this
 document. Please refer to the
-[Wireguard client image](https://github.com/k8s-at-home/container-images/tree/main/wireguard)
+[Wireguard client image](https://github.com/k8s-at-home/container-images/tree/main/apps/wireguard)
 for more details on these environment variables.
 
 !!! note

--- a/docs/our-helm-charts/development/creating-a-new-chart.md
+++ b/docs/our-helm-charts/development/creating-a-new-chart.md
@@ -27,8 +27,9 @@ task chart:create CHART=chart_name
 ```
 
 Second, be sure to checkout the many charts that already use this like
-[qBittorrent](../qbittorrent/), [node-red](../node-red/) or the many others
-in this repository.
+[qBittorrent](https://github.com/k8s-at-home/charts/tree/master/charts/qbittorrent),
+[node-red](https://github.com/k8s-at-home/charts/tree/master/charts/node-red)
+or the many others in this repository.
 
 Include this chart as a dependency in your `Chart.yaml` e.g.
 
@@ -145,8 +146,7 @@ configMap:
 {{ include "common.all" . }}
 ```
 
-An actual example of this can be found in the [zigbee2mqtt](../zigbee2mqtt/)
-chart.
+An actual example of this can be found in the [zigbee2mqtt][zigbee2mqtt] chart.
 
 ### Testing
 
@@ -177,3 +177,5 @@ Be sure to lint your chart to check for any errors.
 task chart:lint CHART=chart_name
 task chart:ct-lint CHART=chart_name
 ```
+
+[zigbee2mqtt]: https://github.com/k8s-at-home/charts/tree/master/charts/zigbee2mqtt

--- a/hack/linkcheck.sh
+++ b/hack/linkcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -o pipefail
+readonly DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )
+for f in $(find "${DIR}" -not -path '*.github*' -name \*.md); do
+  docker run --rm -v /:/tmp:ro -i -w /tmp ghcr.io/tcort/markdown-link-check:stable "/tmp/${f}" || exit 1
+done


### PR DESCRIPTION
**Description of the change**

Add markdown-link-check to task, pre-commit, and lint gh action.

**Benefits**

Checks for deadlinks in the doc.

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #14

**Additional information**

Task script has been added to `hack` dir because task wouldn't loop over all *.md files.
