### PR TITLE
Forgot to add mkdocs.yaml to support

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -120,3 +120,7 @@ nav:
       - Introduction: our-container-images/introduction.md
       - Configuration: our-container-images/configuration.md
       - Permissions: our-container-images/permissions.md
+  - Support:
+      - Community: support/community.md
+      - FAQ: support/faq.md
+      - Code of Conduct: support/code-of-conduct.md


### PR DESCRIPTION
Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>

**Description of the change**

Addes the Support tab to the banner because mkdocs.yml was forgotten in #17

**Benefits**

N/A

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #17

**Additional information**

N/A
