### PR TITLE
Add Build page and fix typos

### DIFF
--- a/docs/our-container-images/development/base-images.md
+++ b/docs/our-container-images/development/base-images.md
@@ -12,6 +12,29 @@ The following distributions are available as a base image:
 
 The source code can be found [here].
 
+## shim scripts
+
+shim scripts have been added to the base images to perform startup tasks
+before the app is launched.
+
+!!! note
+    The shim scripts must be sourced in the [entrypoint.sh] file in order
+    to work.
+
+### config.sh
+
+The `config.sh` shim script is used to create the `/config` folder.
+
+### umask.sh
+
+The `umask.sh` shim script is used to set the setting of a mask that controls
+how file permissions are set for newly created files.
+
+### vpn.sh
+
+The `vpn.sh` shim script is used to allow the container to wait for the VPN
+connection before running the app.
+
 ## Tini
 
 The base images use the [Tini][tini] init in order to create the smallest
@@ -22,3 +45,4 @@ reaping zombies and performing signal forwarding.
 [alpine]: https://github.com/orgs/k8s-at-home/packages/container/package/alpine
 [here]: https://github.com/k8s-at-home/container-images/tree/main/base
 [tini]: https://github.com/krallin/tini/
+[entrypoint.sh]: ./creating-a-new-container-image.md#entrypointsh

--- a/docs/our-container-images/development/base-images.md
+++ b/docs/our-container-images/development/base-images.md
@@ -14,7 +14,7 @@ The source code can be found [here].
 
 ## shim scripts
 
-shim scripts have been added to the base images to perform startup tasks
+shim scripts have been added to the Ubuntu base image to perform startup tasks
 before the app is launched.
 
 !!! note

--- a/docs/our-container-images/development/build.md
+++ b/docs/our-container-images/development/build.md
@@ -1,0 +1,41 @@
+# Build
+
+Building of the container images need to be done from the root directory of the
+repository so that the app files, such as [entrypoint.sh], can be properly
+[copied](./dockerfile.md#copy) into the image.
+
+## Task
+
+[Task][task] may be used to semi-automate the building and loading of a
+container image.
+
+The `APP` parameter will need to be set in order to tell Task which app needs
+to be processed.
+
+Run the following command from the root directory of the repository.
+
+```shell
+task build APP=<app name>
+```
+
+Other tasks can be listed by running `task -l`.
+
+## Manual
+
+The container images can be built and loaded manually by using the Docker cli
+from the repository root directory.
+
+### Build
+
+```shell
+docker buildx build --platform $(cat ./apps/<app name>/PLATFORM) -f ./apps/<app name>/Dockerfile .
+```
+
+### Load
+
+```shell
+docker buildx build -t <app name>:test -f ./apps/<app name>/Dockerfile . --load
+```
+
+[entrypoint.sh]: ./creating-a-new-container-image.md#entrypointsh
+[task]: https://github.com/go-task/task

--- a/docs/our-container-images/development/build.md
+++ b/docs/our-container-images/development/build.md
@@ -28,13 +28,13 @@ from the repository root directory.
 ### Build
 
 ```shell
-docker buildx build --platform $(cat ./apps/<app name>/PLATFORM) -f ./apps/<app name>/Dockerfile .
+docker buildx build --build-arg VERSION=$(cat ./apps/<app name>/VERSION) --platform $(cat ./apps/<app name>/PLATFORM) -f ./apps/<app name>/Dockerfile .
 ```
 
 ### Load
 
 ```shell
-docker buildx build -t <app name>:test -f ./apps/<app name>/Dockerfile . --load
+docker buildx build -t <app name>:test --build-arg VERSION=$(cat ./apps/<app name>/VERSION) -f ./apps/<app name>/Dockerfile . --load
 ```
 
 [entrypoint.sh]: ./creating-a-new-container-image.md#entrypointsh

--- a/docs/our-container-images/development/build.md
+++ b/docs/our-container-images/development/build.md
@@ -4,6 +4,17 @@ Building of the container images need to be done from the root directory of the
 repository so that the app files, such as [entrypoint.sh], can be properly
 [copied](./dockerfile.md#copy) into the image.
 
+## Docker Buildx
+
+[Docker Buildx][buildx] is required to build multi-platform images.
+
+[qemu-user-static] may be used to enable an execution of different
+multi-architecture containers by QEMU and binfmt_misc.
+
+```shell
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+```
+
 ## Task
 
 [Task][task] may be used to semi-automate the building and loading of a
@@ -39,3 +50,5 @@ docker buildx build -t <app name>:test --build-arg VERSION=$(cat ./apps/<app nam
 
 [entrypoint.sh]: ./creating-a-new-container-image.md#entrypointsh
 [task]: https://github.com/go-task/task
+[buildx]: https://docs.docker.com/buildx/working-with-buildx/
+[qemu-user-static]: https://github.com/multiarch/qemu-user-static

--- a/docs/our-container-images/development/creating-a-new-container-image.md
+++ b/docs/our-container-images/development/creating-a-new-container-image.md
@@ -20,6 +20,20 @@ with an already existing app or you can start from scratch.
 image.
 2. Add the following files to the container image folder.
 
+### Folder structure
+
+```shell
+apps/app name/
+     ├── Dockerfile
+     ├── entrypoint.sh
+     ├── goss.yaml
+     ├── latest-version.sh
+     ├── PLATFORM
+     ├── shim
+     │   └── shim-script.sh
+     └── VERSION
+```
+
 ### Dockerfile
 
 See [Dockerfile](./dockerfile.md).

--- a/docs/our-container-images/development/creating-a-new-container-image.md
+++ b/docs/our-container-images/development/creating-a-new-container-image.md
@@ -8,6 +8,7 @@ you will need:
 - [Docker](https://www.docker.com/get-started)
 - [buildx](https://docs.docker.com/buildx/working-with-buildx/)
 - [jq](https://stedolan.github.io/jq/)
+- [goss] & [dgoss]
 - [task (optional)](https://github.com/go-task/task)
 
 ## Creating a new container image
@@ -76,7 +77,7 @@ source "/shim/<app name>-preferences.sh"
 
 ### goss.yaml
 
-The `VERSION` file is used by the
+The `goss.yaml` file is used by the
 [Apps - Build, Test, Push github action][apps.yaml] to perform a health
 check on the container image using [goss](https://github.com/aelsabbahy/goss).
 
@@ -136,6 +137,9 @@ Then be sure to add a `source` line to the [entrypoint.sh script](#entrypointsh)
 
 See [plex-media-server] for reference.
 
+[goss]: https://github.com/aelsabbahy/goss
+[dgoss]: https://github.com/aelsabbahy/goss/tree/master/extras/dgoss
+[apps-schedule.yaml]: https://github.com/k8s-at-home/container-images/actions/workflows/apps-schedule.yaml
 [apps.yaml]: https://github.com/k8s-at-home/container-images/actions/workflows/apps.yaml
 [manual]: https://github.com/aelsabbahy/goss/blob/master/docs/manual.md
 [multi-platform]: https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images

--- a/docs/our-container-images/development/creating-a-new-container-image.md
+++ b/docs/our-container-images/development/creating-a-new-container-image.md
@@ -60,7 +60,7 @@ This file will most likely be custom for each app. It is recommended to take a
 look at other container images or other versions of the Docker image for the
 app. A good source might be searching [Docker Hub](https://hub.docker.com/).
 
-The only difference is the sourcing of the `umask.sh` and `vpn.sh` scripts
+The only difference is the sourcing of the [base image shim scripts]
 which are added to the base image.
 
 ```bash
@@ -137,6 +137,7 @@ Then be sure to add a `source` line to the [entrypoint.sh script](#entrypointsh)
 
 See [plex-media-server] for reference.
 
+[base image shim scripts]: ./base-images.md#shim-scripts
 [goss]: https://github.com/aelsabbahy/goss
 [dgoss]: https://github.com/aelsabbahy/goss/tree/master/extras/dgoss
 [apps-schedule.yaml]: https://github.com/k8s-at-home/container-images/actions/workflows/apps-schedule.yaml

--- a/docs/our-helm-charts/development/creating-a-new-chart.md
+++ b/docs/our-helm-charts/development/creating-a-new-chart.md
@@ -9,7 +9,7 @@ a few tools you will need.
 - [helm-docs](https://github.com/norwoodj/helm-docs)
 - [task](https://github.com/go-task/task) (optional)
 
-## Creating a new Chart
+## Creating a new chart
 
 To create a new chart, run the following:
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -125,6 +125,7 @@ nav:
               our-container-images/development/creating-a-new-container-image.md
           - Dockerfile: our-container-images/development/dockerfile.md
           - Base images: our-container-images/development/base-images.md
+          - Build: our-container-images/development/build.md
   - Support:
       - Community: support/community.md
       - FAQ: support/faq.md


### PR DESCRIPTION

**Description of the change**

Add build.md and fix typos.

- Changed capitalization of Creating a new chart
- Fixed typos
- Add build.md
- Added shim scripts section
- Added link the base image shim scripts
- Reworded shim scripts description
- Added --build-arg VERSION to build and load commands
- Added Docker Buildx section
- Added development/build.md

**Benefits**

Gives instructions on how to build container images.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
