### PR TITLE
Add EXTRA_ARGS to entrypoint.sh

### DIFF
--- a/docs/our-container-images/development/creating-a-new-container-image.md
+++ b/docs/our-container-images/development/creating-a-new-container-image.md
@@ -83,10 +83,19 @@ source "/shim/umask.sh"
 source "/shim/vpn.sh"
 ```
 
-If the app has custom [shim scripts](#shim-scripts), be sure to source those as well.
+If the app has custom [shim scripts](#shim-scripts), be sure to source those
+as well.
 
 ```shell
 source "/shim/<app name>-preferences.sh"
+```
+
+Ensure to append the `${EXTRA_ARGS}` environmental variable to the end of the
+`exec` command so that extra args can be passed to the container by the helm
+chart.
+
+```shell
+exec /app/foo ${EXTRA_ARGS}
 ```
 
 ### goss.yaml


### PR DESCRIPTION
Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>

**Description of the change**

Add `${EXTRA_ARGS}` to `entrypoint.sh` on Creating a new container image page.

**Benefits**

Gives direction on why to add `${EXTRA_ARGS}` to the `entrypoint.sh` file.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A